### PR TITLE
Add pagination

### DIFF
--- a/lib/moneybird/client.rb
+++ b/lib/moneybird/client.rb
@@ -54,7 +54,7 @@ module Moneybird
       while path
         response = http.get(path, options)
         yield response.body
-        path = response[:pagination_links]&.next
+        path = (response[:pagination_links].next if response[:pagination_links])
       end
     end
 

--- a/lib/moneybird/client.rb
+++ b/lib/moneybird/client.rb
@@ -28,6 +28,10 @@ module Moneybird
         faraday.request :url_encoded
         faraday.response :json
         faraday.use Moneybird::Middleware::ErrorHandling
+        faraday.use Moneybird::Middleware::Pagination
+        # faraday.response :logger do |logger|
+        #   logger.filter(/(Bearer)\s(\S+)/, '\1[REMOVED]')
+        # end
         faraday.adapter faraday_adapter
       end
     end
@@ -35,6 +39,22 @@ module Moneybird
     %i[get patch post delete].each do |call|
       define_method call do |path, options = {}|
         http.public_send(call, "/api/#{version}/#{path}", options).body
+      end
+    end
+
+    def get_all_pages(path, options = {})
+      get_each_page(path, options).inject([]) do |array, objects|
+        array += objects
+      end
+    end
+
+    def get_each_page(path, options = {})
+      return enum_for(:get_each_page, path, options) unless block_given?
+      path = "/api/#{version}/#{path}"
+      while path
+        response = http.get(path, options)
+        yield response.body
+        path = response[:pagination_links]&.next
       end
     end
 

--- a/lib/moneybird/middleware/pagination.rb
+++ b/lib/moneybird/middleware/pagination.rb
@@ -1,0 +1,29 @@
+require 'link_header'
+
+module Moneybird
+  module Middleware
+    class Pagination < Faraday::Response::Middleware
+      def on_complete(response)
+        return unless response[:response_headers]
+        link_header = response[:response_headers][:link]
+        return unless link_header
+        response[:response_headers][:pagination_links] = find_links(link_header)
+      end
+
+      private
+
+      def find_links(link_header)
+        Links.new.tap do |links|
+          %w[prev next first last current].each do |page|
+            links.public_send("#{page}=", find_link(link_header, page))
+          end
+        end
+      end
+
+      def find_link(header, rel)
+        link = ::LinkHeader.parse(header).links.find { |l| l['rel'] == rel }
+        link.to_a.first if link
+      end
+    end
+  end
+end

--- a/lib/moneybird/middleware/pagination/links.rb
+++ b/lib/moneybird/middleware/pagination/links.rb
@@ -1,0 +1,17 @@
+require 'link_header'
+
+module Moneybird
+  module Middleware
+    class Pagination < Faraday::Response::Middleware
+      class Links
+        attr_accessor :first, :prev, :current, :next, :last
+        alias previous prev
+        alias prevous= prev=
+
+        def last_page?
+          !current.nil? && !last.nil? && current == last
+        end
+      end
+    end
+  end
+end

--- a/lib/moneybird/traits/find_all.rb
+++ b/lib/moneybird/traits/find_all.rb
@@ -1,9 +1,41 @@
 module Moneybird
   module Traits
     module FindAll
-      def all
-        client.get(path).map do |resource|
+      def all(params = {})
+        each(params).to_a
+      end
+
+      def each_page(params = {})
+        return enum_for(:each_page, params) unless block_given?
+        client.get_each_page(path, params).map do |resources|
+          yield resources.map { |resource| build resource }
+        end
+      end
+
+      def each(params = {})
+        return enum_for(:each, params) unless block_given?
+        each_page(params).each do |resources|
+          resources.each do |resource|
+            yield resource
+          end
+        end
+      end
+
+      def first_page(params = {})
+        client.get(path, params).map do |resource|
           build resource
+        end
+      end
+
+      def first(params = {})
+        params = { per_page: 1 }.merge params
+        build client.get(path, params).first
+      end
+
+      def map(params = {})
+        return enum_for(:map, params) unless block_given?
+        each(params).map do |resource|
+          yield resource
         end
       end
     end

--- a/moneybird.gemspec
+++ b/moneybird.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", '>= 0.12'
   spec.add_dependency "faraday"
   spec.add_dependency "faraday_middleware"
+  spec.add_dependency "link_header", "~> 0.0.8"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "codeclimate-test-reporter"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "webmock", "~> 3.1"
-
 end

--- a/spec/lib/moneybird/client_spec.rb
+++ b/spec/lib/moneybird/client_spec.rb
@@ -7,29 +7,64 @@ describe Moneybird::Client do
     client.bearer_token.must_equal 'bearer token'
   end
 
-  describe "request handling" do
-    it "can do a post request" do
+  describe '#http' do
+    it 'returns a faraday connection object' do
+      client.http.must_be_instance_of Faraday::Connection
+    end
+    it 'sets the token to the authorization header' do
+      client.http.headers['Authorization'].must_equal 'Bearer bearer token'
+    end
+    it 'sets the url to the specified domain' do
+      client.http.url_prefix.to_s.must_equal 'https://moneybird.com/'
+    end
+  end
+
+  describe "#post" do
+    it "posts and parses json" do
       stub_request(:post, 'https://moneybird.com/api/v2/path')
         .to_return(status: 200, body: { foo: 'bar' }.to_json)
       client.post('/path', 'body').must_equal('foo' => 'bar')
     end
+  end
 
-    it "can do a get request" do
+  describe '#get' do
+    it "gets and parses json" do
       stub_request(:get, 'https://moneybird.com/api/v2/path')
         .to_return(status: 200, body: { foo: 'bar' }.to_json)
       client.get('/path').must_equal('foo' => 'bar')
     end
+  end
 
-    it "can do a patch request" do
+  describe '#patch' do
+    it "patches and parses json" do
       stub_request(:patch, 'https://moneybird.com/api/v2/path')
         .to_return(status: 200, body: { foo: 'bar' }.to_json)
       client.patch('/path', 'body').must_equal('foo' => 'bar')
     end
+  end
 
-    it "can do a delete request" do
+  describe '#delete' do
+    it "deletes and parses json" do
       stub_request(:delete, 'https://moneybird.com/api/v2/path')
         .to_return(status: 200, body: { foo: 'bar' }.to_json)
       client.delete('/path').must_equal('foo' => 'bar')
+    end
+  end
+
+  describe '#get_all_pages' do
+    it 'gets and parses all pages in json' do
+      stub_request(:get, 'https://moneybird.com/api/v2/path')
+        .to_return(
+          status: 200,
+          body: '[{"id":"1"}, {"id":"2"}]',
+          headers: {
+            'Link' => '<https://moneybird.com/api/v2/path?page=2>; rel="next"'
+          }
+        )
+      stub_request(:get, 'https://moneybird.com/api/v2/path?page=2')
+        .to_return(status: 200, body: '[{"id":"3"}, {"id":"4"}]')
+
+      client.get_all_pages('/path').must_equal([{ 'id' => '1' }, { 'id' => '2' }, { 'id' => '3' }, { 'id' => '4' }])
     end
   end
 end

--- a/spec/lib/moneybird/middleware/pagination_spec.rb
+++ b/spec/lib/moneybird/middleware/pagination_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+describe Moneybird::Middleware::Pagination do
+  let(:client) { Moneybird::Client.new("bearer token") }
+  let(:pagination_links_header) { client.http.get('/api/v2/administrations', per_page: 10)[:pagination_links] }
+
+  before do
+    stub_request(:get, "https://moneybird.com/api/v2/administrations?per_page=10").
+      to_return(
+        status: 200,
+        body: fixture_response(:administrations),
+        headers: {
+          'Link' => '<https://moneybird.com/api/v2/administrations.json?page=3>; rel="next", <https://moneybird.com/api/v2/administrations.json?page=1>; rel="prev"'
+        }
+      )
+  end
+
+  it 'returns a links object' do
+    pagination_links_header.must_be_instance_of Moneybird::Middleware::Pagination::Links
+  end
+
+  it 'returns a next url' do
+    pagination_links_header.next.must_equal 'https://moneybird.com/api/v2/administrations.json?page=3'
+  end
+
+  it 'returns a prev url' do
+    pagination_links_header.prev.must_equal 'https://moneybird.com/api/v2/administrations.json?page=1'
+  end
+
+  it 'returns a previous url' do
+    pagination_links_header.previous.must_equal 'https://moneybird.com/api/v2/administrations.json?page=1'
+  end
+end


### PR DESCRIPTION
As promised, the pull request for pagination. It makes use of the [link header](https://github.com/asplake/link_header) gem. I know this is a quite old gem but it has served my purposes in the past as well and still works like a charm. 

The pagination also makes use of the Faraday middleware. On each request, the link header is checked and if present, parsed by the link header gem. The `find_all` methods now actually get all records. To make it a bit more user friendly I've added some more methods like `each`, `each_page` and `first_page`. Each of these functions accepts an argument hash which can be used to say how many items you want per page. So for example `administration.contacts.all(per_page: 10)` gets all contacts in batches of 10. 

Let me know what you think! I think you can expect some more pull requests in the near future since we are now heavily using this gem and come across multiple issues. 