### PR TITLE
Fix saving of invoice due to method naming issues

### DIFF
--- a/lib/moneybird/traits/send_invoice.rb
+++ b/lib/moneybird/traits/send_invoice.rb
@@ -1,12 +1,12 @@
 module Moneybird
   module Traits
     module SendInvoice
-      def resource_path(resource)
+      def send_invoice_path(resource)
         [path, resource.path, '/send_invoice'].join('')
       end
 
       def send_invoice(resource, options = {})
-        client.patch(resource_path(resource), options.to_json)
+        client.patch(send_invoice_path(resource), options.to_json)
       end
     end
   end

--- a/spec/fixtures/responses/sales_invoice.json
+++ b/spec/fixtures/responses/sales_invoice.json
@@ -1,0 +1,135 @@
+{
+  "id": "181903552510166047",
+  "administration_id": 123,
+  "contact_id": "181903552404259868",
+  "contact": {
+    "id": "181903552404259868",
+    "administration_id": 123,
+    "company_name": "Foobar Holding B.V.",
+    "firstname": "",
+    "lastname": "",
+    "address1": "Hoofdstraat 12",
+    "address2": "",
+    "zipcode": "1234AB",
+    "city": "Amsterdam",
+    "country": "NL",
+    "phone": "",
+    "delivery_method": "Email",
+    "customer_id": "1",
+    "tax_number": "",
+    "chamber_of_commerce": "",
+    "bank_account": "",
+    "attention": "",
+    "email": "info@example.com",
+    "email_ubl": true,
+    "send_invoices_to_attention": "",
+    "send_invoices_to_email": "info@example.com",
+    "send_estimates_to_attention": "",
+    "send_estimates_to_email": "info@example.com",
+    "sepa_active": false,
+    "sepa_iban": "",
+    "sepa_iban_account_name": "",
+    "sepa_bic": "",
+    "sepa_mandate_id": "",
+    "sepa_mandate_date": null,
+    "sepa_sequence_type": "FRST",
+    "credit_card_number": "",
+    "credit_card_reference": "",
+    "credit_card_type": null,
+    "tax_number_validated_at": null,
+    "created_at": "2017-02-21T17:06:07.710Z",
+    "updated_at": "2017-02-21T17:06:07.710Z",
+    "sales_invoices_url": "http://moneybird.dev/123/sales_invoices/e807722dc8338cfa5b7ca895a78bd49868385b145730027758013f7a780a7890/all",
+    "notes": [
+
+    ],
+    "custom_fields": [
+
+    ]
+  },
+  "invoice_id": "2017-0001",
+  "recurring_sales_invoice_id": null,
+  "workflow_id": "181903403083892150",
+  "document_style_id": "181903403938481600",
+  "identity_id": "181903402453697973",
+  "draft_id": null,
+  "state": "open",
+  "invoice_date": "2017-02-21",
+  "due_date": "2017-03-07",
+  "payment_conditions": "We verzoeken u vriendelijk het bovenstaande bedrag van {document.total_price} voor {document.due_date} te voldoen op onze bankrekening onder vermelding van het factuurnummer {document.invoice_id}. Voor vragen kunt u contact opnemen per e-mail.",
+  "reference": "Project X",
+  "language": "nl",
+  "currency": "EUR",
+  "discount": "0.0",
+  "original_sales_invoice_id": null,
+  "paid_at": null,
+  "sent_at": "2017-02-21",
+  "created_at": "2017-02-21T17:06:07.811Z",
+  "updated_at": "2017-02-21T17:06:08.005Z",
+  "details": [
+    {
+      "id": "181903552513311776",
+      "administration_id": 123,
+      "tax_rate_id": "181903402082502063",
+      "ledger_account_id": "181903401873835420",
+      "amount": "1 x",
+      "description": "Project X",
+      "price": "300.0",
+      "period": "20170201..20170228",
+      "row_order": 1,
+      "total_price_excl_tax_with_discount": "300.0",
+      "total_price_excl_tax_with_discount_base": "300.0",
+      "tax_report_reference": [
+        "NL/1a"
+      ],
+      "created_at": "2017-02-21T17:06:07.815Z",
+      "updated_at": "2017-02-21T17:06:08.002Z"
+    }
+  ],
+  "payments": [
+
+  ],
+  "total_paid": "0.0",
+  "total_unpaid": "363.0",
+  "total_unpaid_base": "363.0",
+  "prices_are_incl_tax": false,
+  "total_price_excl_tax": "300.0",
+  "total_price_excl_tax_base": "300.0",
+  "total_price_incl_tax": "363.0",
+  "total_price_incl_tax_base": "363.0",
+  "url": "http://moneybird.dev/123/sales_invoices/7090c100b6c2c3a3f0dfb7c5f21431c5fa5b40817c091e4b1941234cc209d8ea/e807722dc8338cfa5b7ca895a78bd49868385b145730027758013f7a780a7890",
+  "custom_fields": [
+
+  ],
+  "notes": [
+
+  ],
+  "attachments": [
+
+  ],
+  "events": [
+    {
+      "administration_id": 123,
+      "user_id": 14876966215920,
+      "action": "sales_invoice_created",
+      "link_entity_id": null,
+      "link_entity_type": null,
+      "data": null,
+      "created_at": "2017-02-21T17:06:07.822Z",
+      "updated_at": "2017-02-21T17:06:07.822Z"
+    },
+    {
+      "administration_id": 123,
+      "user_id": 14876966215920,
+      "action": "sales_invoice_send_email",
+      "link_entity_id": null,
+      "link_entity_type": null,
+      "data": {
+        "email_address": "info@example.com",
+        "email_message": "Geachte Foobar Holding B.V.,\n\nIn de bijlage kunt u factuur 2017-0001 voor onze diensten vinden. Wij verzoeken u vriendelijk de factuur voor 07-03-2017 te voldoen.\n\nMet vriendelijke groet,\n\nParkietje B.V."
+      },
+      "created_at": "2017-02-21T17:06:08.063Z",
+      "updated_at": "2017-02-21T17:06:08.063Z"
+    }
+  ]
+}

--- a/spec/lib/moneybird/service/sales_invoice_spec.rb
+++ b/spec/lib/moneybird/service/sales_invoice_spec.rb
@@ -18,6 +18,28 @@ describe Moneybird::Service::SalesInvoice do
     end
   end
 
+  describe "#save" do
+    let(:id) { '1' }
+    let(:attributes) { { id: id, reference: 'FooBar' } }
+
+    it "creates when not persisted" do
+      stub_request(:post, "https://moneybird.com/api/v2/123/sales_invoices")
+        .to_return(status: 201, body: fixture_response(:sales_invoice))
+      attributes.delete(:id)
+
+      resource = service.build(attributes)
+      service.save(resource).must_equal resource
+    end
+
+    it "updates when persisted" do
+      stub_request(:patch, "https://moneybird.com/api/v2/123/sales_invoices/#{id}")
+        .to_return(status: 200, body: fixture_response(:sales_invoice))
+
+      resource = service.build(attributes)
+      service.save(resource).must_equal resource
+    end
+  end
+
   describe "#send" do
     before do
       stub_request(:patch, 'https://moneybird.com/api/v2/123/sales_invoices/456/send_invoice')


### PR DESCRIPTION
The creation and updating of an invoice fails in the current version! This is because the `SendInvoice` trait uses the same name for the path as the `Save` trait. So I've changed the naming of the `SendInvoice` trait and added a test to cover this. 

We should probably test all methods of all services since this could have been prevented quite easily. Let's do this before we release 1.0.