### PR TITLE
Return result of send_invoice as an invoice object

### DIFF
--- a/lib/moneybird/traits/send_invoice.rb
+++ b/lib/moneybird/traits/send_invoice.rb
@@ -6,7 +6,9 @@ module Moneybird
       end
 
       def send_invoice(resource, options = {})
-        client.patch(send_invoice_path(resource), options.to_json)
+        response = client.patch(send_invoice_path(resource), options.to_json)
+        resource.attributes = response
+        resource
       end
     end
   end

--- a/moneybird.gemspec
+++ b/moneybird.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday_middleware"
   spec.add_dependency "link_header", "~> 0.0.8"
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", [">= 1.11", "< 3.0"]
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "codeclimate-test-reporter"
   spec.add_development_dependency "minitest"

--- a/spec/lib/moneybird/service/sales_invoice_spec.rb
+++ b/spec/lib/moneybird/service/sales_invoice_spec.rb
@@ -40,14 +40,14 @@ describe Moneybird::Service::SalesInvoice do
     end
   end
 
-  describe "#send" do
+  describe "#send_invoice" do
     before do
       stub_request(:patch, 'https://moneybird.com/api/v2/123/sales_invoices/456/send_invoice')
-        .to_return(status: 200)
+        .to_return(status: 200, body: fixture_response(:sales_invoice))
     end
     let(:sales_invoice) { Moneybird::Resource::SalesInvoice.new(client: client, id: '456') }
     it "will send the invoice" do
-      service.send_invoice(sales_invoice)
+      service.send_invoice(sales_invoice).must_equal sales_invoice
     end
   end
 end


### PR DESCRIPTION
The send_invoice API call returns the invoice object. Returning it allows the generated invoice number to be retrieved without an extra round-trip to fetch the new invoice state.