### PR TITLE
Add si_identifier and si_identifier_type to Contact resource

### DIFF
--- a/lib/moneybird/resource/contact.rb
+++ b/lib/moneybird/resource/contact.rb
@@ -43,6 +43,8 @@ module Moneybird::Resource
       sepa_mandate_date
       sepa_mandate_id
       sepa_sequence_type
+      si_identifier
+      si_identifier_type
       tax_number
       tax_number_valid
       tax_number_validated_at


### PR DESCRIPTION
The Moneybird gem kept warning me about:
```
W, [2019-11-04T13:02:33.800623 #24299]  WARN -- : Moneybird::Resource::Contact does not have an `si_identifier' attribute
W, [2019-11-04T13:02:33.800687 #24299]  WARN -- : Moneybird::Resource::Contact does not have an `si_identifier_type' attribute
```

The fields are used for Simplerinvoicing. https://www.moneybird.nl/simplerinvoicing/
I dont need them, but the warning was pretty annoying :)