### PR TITLE
Add project_id to Moneybird::Resource::Invoice::Details

### DIFF
--- a/lib/moneybird/resource/invoice/details.rb
+++ b/lib/moneybird/resource/invoice/details.rb
@@ -14,6 +14,7 @@ module Moneybird::Resource::Invoice
       period
       price
       product_id
+      project_id
       row_order
       tax_rate_id
       tax_report_reference


### PR DESCRIPTION
The Moneybird gem kept warning me about:

```
W, [2019-11-29T16:50:39.787214 #14069]  WARN -- : Moneybird::Resource::Invoice::Details does not have an `project_id' attribute
```