### PR TITLE
Fix undefined method `[]' for nil:NilClass in Webhook#build_entity

### DIFF
--- a/lib/moneybird/webhook.rb
+++ b/lib/moneybird/webhook.rb
@@ -14,7 +14,7 @@ module Moneybird
     )
 
     def build_entity
-      entity_resource_class.new(entity)
+      entity_resource_class.new(entity) if entity
     end
 
     def entity_resource_class

--- a/spec/fixtures/webhooks/delete_sales_invoice.json
+++ b/spec/fixtures/webhooks/delete_sales_invoice.json
@@ -1,0 +1,8 @@
+{
+  "administration_id": 116015326147118082,
+  "webhook_id": 116010948233266179,
+  "entity_type": "SalesInvoice",
+  "entity_id": 116015245643744263,
+  "state": "late",
+  "entity": null
+}

--- a/spec/lib/moneybird/webhook_spec.rb
+++ b/spec/lib/moneybird/webhook_spec.rb
@@ -14,4 +14,12 @@ describe Moneybird::Webhook do
   it "knows the api entity" do
     webhook.entity_resource_class.must_equal Moneybird::Resource::SalesInvoice
   end
+
+  describe "without entity data" do
+    let(:webhook) { Moneybird::Webhook.from_json(fixture_response(:delete_sales_invoice, :webhooks)) }
+
+    it "returns nil" do
+      webhook.build_entity.must_be_nil
+    end
+  end
 end


### PR DESCRIPTION
When a SalesInvoice is deleted, the webhook is called without entity data. This pr fixes handling JSON data without entity attribute. (#45 )