### PR TITLE
Adding new transaction_identifier field to payments

### DIFF
--- a/lib/moneybird/resource/invoice/payment.rb
+++ b/lib/moneybird/resource/invoice/payment.rb
@@ -16,6 +16,7 @@ module Moneybird::Resource::Invoice
       payment_transaction_id
       price
       price_base
+      transaction_identifier
       updated_at
       user_id
     )


### PR DESCRIPTION
Adding new `transaction_identifier` field to `payments` based on https://developer.moneybird.com/changelog/

> **Changelog 19-11-2019**
> 
> We have added a `transaction_identifier` field to `payments`. This allows you to store the identifier of a Payment Service Provider transaction. If you use Mollie for payments, the identifier will be used to automatically link the payments to the pay out of Mollie on your bank account.
