### PR TITLE
Add missing webhook token attribute

### DIFF
--- a/lib/moneybird/resource/webhook.rb
+++ b/lib/moneybird/resource/webhook.rb
@@ -10,6 +10,7 @@ module Moneybird::Resource
       last_http_status
       last_http_body
       events
+      token
     )
 
     def to_json

--- a/lib/moneybird/webhook.rb
+++ b/lib/moneybird/webhook.rb
@@ -6,6 +6,7 @@ module Moneybird
     has_attributes %i(
       administration_id
       webhook_id
+      webhook_token
       entity_type
       entity_id
       state


### PR DESCRIPTION
Moneybird has added a webhook token attribute to verify that the webhook event originated from Moneybird.

This PR whitelists the attributes so the application can store and verify the requests.

> ### Changelog 08-08-2019
> Webhooks now have a unique secret key, given in the ‘token’ field on creation. This token is also given with each webhook call in the ‘webhook_token’ field. It can be used to verify that the webhook call comes from Moneybird.