### PR TITLE
Add support for downloading sales invoices

### DIFF
--- a/lib/moneybird.rb
+++ b/lib/moneybird.rb
@@ -69,13 +69,14 @@ require 'moneybird/resource/workflow'
 # Traits
 require 'moneybird/traits/administration_service'
 require 'moneybird/traits/delete'
+require 'moneybird/traits/download_pdf'
 require 'moneybird/traits/find'
 require 'moneybird/traits/find_all'
 require 'moneybird/traits/mark_as_uncollectible'
 require 'moneybird/traits/save'
+require 'moneybird/traits/send_invoice'
 require 'moneybird/traits/service'
 require 'moneybird/traits/synchronization' # Depends on synchronization resource
-require 'moneybird/traits/send_invoice'
 
 ##
 # Services (all depend on traits and it's associated resource)

--- a/lib/moneybird/client.rb
+++ b/lib/moneybird/client.rb
@@ -40,6 +40,12 @@ module Moneybird
       end
     end
 
+    def get_redirect_url(path, options = {})
+      res = http.get("/api/#{version}/#{path}", options)
+    rescue Faraday::ParsingError => e
+      e.response['Location']
+    end
+
     def get_all_pages(path, options = {})
       get_each_page(path, options).inject([]) do |array, objects|
         array += objects

--- a/lib/moneybird/client.rb
+++ b/lib/moneybird/client.rb
@@ -37,13 +37,12 @@ module Moneybird
     %i[get patch post delete].each do |call|
       define_method call do |path, options = {}|
         http.public_send(call, "/api/#{version}/#{path}", options).body
-      end
-    end
 
-    def get_redirect_url(path, options = {})
-      res = http.get("/api/#{version}/#{path}", options)
-    rescue Faraday::ParsingError => e
-      e.response['Location']
+      rescue Faraday::ParsingError => e
+        return e.response['Location'] if e.response.status == 302
+
+        raise e
+      end
     end
 
     def get_all_pages(path, options = {})

--- a/lib/moneybird/resource/sales_invoice.rb
+++ b/lib/moneybird/resource/sales_invoice.rb
@@ -62,6 +62,11 @@ module Moneybird::Resource
       @contact = Moneybird::Resource::Contact.build(attributes)
     end
 
+    def download_pdf(options = {})
+      invoice_service = Moneybird::Service::SalesInvoice.new(client, administration_id)
+      invoice_service.download_pdf(self, options)
+    end
+
     def send_invoice(options = {})
       invoice_service = Moneybird::Service::SalesInvoice.new(client, administration_id)
       invoice_service.send_invoice(self, options)

--- a/lib/moneybird/resource/sales_invoice.rb
+++ b/lib/moneybird/resource/sales_invoice.rb
@@ -62,11 +62,6 @@ module Moneybird::Resource
       @contact = Moneybird::Resource::Contact.build(attributes)
     end
 
-    def download_pdf(options = {})
-      invoice_service = Moneybird::Service::SalesInvoice.new(client, administration_id)
-      invoice_service.download_pdf(self, options)
-    end
-
     def send_invoice(options = {})
       invoice_service = Moneybird::Service::SalesInvoice.new(client, administration_id)
       invoice_service.send_invoice(self, options)

--- a/lib/moneybird/service/sales_invoice.rb
+++ b/lib/moneybird/service/sales_invoice.rb
@@ -7,6 +7,7 @@ module Moneybird::Service
     include Moneybird::Traits::Save
     include Moneybird::Traits::Delete
     include Moneybird::Traits::Synchronization
+    include Moneybird::Traits::DownloadPdf
     include Moneybird::Traits::SendInvoice
     include Moneybird::Traits::MarkAsUncollectible
 

--- a/lib/moneybird/traits/download_pdf.rb
+++ b/lib/moneybird/traits/download_pdf.rb
@@ -1,0 +1,13 @@
+module Moneybird
+  module Traits
+    module DownloadPdf
+      def download_pdf_path(resource)
+        [path, resource.path, '/download_pdf'].join('')
+      end
+
+      def download_pdf(resource, options = {})
+        client.get_redirect_url(download_pdf_path(resource))
+      end
+    end
+  end
+end

--- a/lib/moneybird/traits/download_pdf.rb
+++ b/lib/moneybird/traits/download_pdf.rb
@@ -1,12 +1,8 @@
 module Moneybird
   module Traits
     module DownloadPdf
-      def download_pdf_path(resource)
-        [path, resource.path, '/download_pdf'].join('')
-      end
-
-      def download_pdf(resource, options = {})
-        client.get_redirect_url(download_pdf_path(resource))
+      def download_pdf(id)
+        client.get("#{path}/#{id}/download_pdf")
       end
     end
   end

--- a/spec/lib/moneybird/service/sales_invoice_spec.rb
+++ b/spec/lib/moneybird/service/sales_invoice_spec.rb
@@ -51,6 +51,21 @@ describe Moneybird::Service::SalesInvoice do
     end
   end
 
+  describe "#download_pdf" do
+    before do
+      stub_request(:get, 'https://moneybird.com/api/v2/123/sales_invoices/456/download_pdf')
+        .to_return(
+          status: 302,
+          body: 'This resource has been moved temporarily.',
+          headers: {
+            'Location' => 'https://storage.moneybird.dev/036ce3bd95c725c04aa5b81ee9419f9b49246a4b91483c2ad913e31a99204fa6/36cabf4c517ca62001f1bd3c9e014b0cacb2f77e9c24ab432c72ca6dc1820b6e/download'
+          })
+    end
+    it "will return download url" do
+      service.download_pdf(456).must_equal 'https://storage.moneybird.dev/036ce3bd95c725c04aa5b81ee9419f9b49246a4b91483c2ad913e31a99204fa6/36cabf4c517ca62001f1bd3c9e014b0cacb2f77e9c24ab432c72ca6dc1820b6e/download'
+    end
+  end
+
   describe "#mark_as_uncollectible" do
     before do
       stub_request(:patch, 'https://moneybird.com/api/v2/123/sales_invoices/456/mark_as_uncollectible')


### PR DESCRIPTION
Support downloading sales invoices via /sales_invoices/:id/download_pdf.

This PR also fixes issue #46.

