### PR TITLE
Remove memoization from remaining resource attribute setters

### DIFF
--- a/lib/moneybird/resource/contact.rb
+++ b/lib/moneybird/resource/contact.rb
@@ -54,15 +54,15 @@ module Moneybird::Resource
     )
 
     def notes=(notes)
-      @notes ||= notes.map{ |note| Moneybird::Resource::Generic::Note.build(note) }
+      @notes = notes.map{ |note| Moneybird::Resource::Generic::Note.build(note) }
     end
 
     def events=(events)
-      @events ||= events.map{ |event| Moneybird::Resource::Generic::Event.build(event) }
+      @events = events.map{ |event| Moneybird::Resource::Generic::Event.build(event) }
     end
 
     def custom_fields=(custom_fields)
-      @custom_fields ||= custom_fields.map { |custom_field| Moneybird::Resource::CustomField.build(custom_field) }
+      @custom_fields = custom_fields.map { |custom_field| Moneybird::Resource::CustomField.build(custom_field) }
     end
   end
 end

--- a/lib/moneybird/resource/documents/purchase_invoice.rb
+++ b/lib/moneybird/resource/documents/purchase_invoice.rb
@@ -35,7 +35,7 @@ module Moneybird::Resource::Documents
     )
 
     def notes=(notes)
-      @notes ||= notes.map{ |note| Moneybird::Resource::Generic::Note.build(note) }
+      @notes = notes.map{ |note| Moneybird::Resource::Generic::Note.build(note) }
     end
 
     def contact=(attributes)
@@ -47,11 +47,11 @@ module Moneybird::Resource::Documents
     end
 
     def events=(events)
-      @events ||= events.map{ |event| Moneybird::Resource::Generic::Event.build(event) }
+      @events = events.map{ |event| Moneybird::Resource::Generic::Event.build(event) }
     end
 
     def payments=(payments)
-      @payments ||= payments.map{ |payment| Moneybird::Resource::Invoice::Payment.build(payment) }
+      @payments = payments.map{ |payment| Moneybird::Resource::Invoice::Payment.build(payment) }
     end
   end
 end

--- a/lib/moneybird/resource/documents/receipt.rb
+++ b/lib/moneybird/resource/documents/receipt.rb
@@ -35,7 +35,7 @@ module Moneybird::Resource::Documents
     )
 
     def notes=(notes)
-      @notes ||= notes.map{ |note| Moneybird::Resource::Generic::Note.build(note) }
+      @notes = notes.map{ |note| Moneybird::Resource::Generic::Note.build(note) }
     end
 
     def contact=(attributes)
@@ -47,11 +47,11 @@ module Moneybird::Resource::Documents
     end
 
     def events=(events)
-      @events ||= events.map{ |event| Moneybird::Resource::Generic::Event.build(event) }
+      @events = events.map{ |event| Moneybird::Resource::Generic::Event.build(event) }
     end
 
     def payments=(payments)
-      @payments ||= payments.map{ |payment| Moneybird::Resource::Invoice::Payment.build(payment) }
+      @payments = payments.map{ |payment| Moneybird::Resource::Invoice::Payment.build(payment) }
     end
   end
 end

--- a/lib/moneybird/resource/estimate.rb
+++ b/lib/moneybird/resource/estimate.rb
@@ -48,15 +48,15 @@ module Moneybird::Resource
     )
 
     def notes=(notes)
-      @notes ||= notes.map{ |note| Moneybird::Resource::Generic::Note.build(note) }
+      @notes = notes.map{ |note| Moneybird::Resource::Generic::Note.build(note) }
     end
 
     def contact=(attributes)
-      @contact ||= Moneybird::Resource::Contact.build(attributes)
+      @contact = Moneybird::Resource::Contact.build(attributes)
     end
 
     def details=(line_items)
-      @details ||= line_items.map{ |line_item| Moneybird::Resource::Invoice::Details.build(line_item) }
+      @details = line_items.map{ |line_item| Moneybird::Resource::Invoice::Details.build(line_item) }
     end
   end
 end

--- a/lib/moneybird/resource/external_sales_invoice.rb
+++ b/lib/moneybird/resource/external_sales_invoice.rb
@@ -38,7 +38,7 @@ module Moneybird::Resource
     )
 
     def notes=(notes)
-      @notes ||= notes.map{ |note| Moneybird::Resource::Generic::Note.build(note) }
+      @notes = notes.map{ |note| Moneybird::Resource::Generic::Note.build(note) }
     end
 
     def contact=(attributes)
@@ -55,7 +55,7 @@ module Moneybird::Resource
     end
 
     def events=(events)
-      @events ||= events.map{ |event| Moneybird::Resource::Generic::Event.build(event) }
+      @events = events.map{ |event| Moneybird::Resource::Generic::Event.build(event) }
     end
   end
 end

--- a/lib/moneybird/resource/identity.rb
+++ b/lib/moneybird/resource/identity.rb
@@ -24,6 +24,6 @@ module Moneybird::Resource
   end
 
   def custom_fields=(custom_fields)
-    @custom_fields ||= custom_fields.map { |custom_field| Moneybird::Resource::CustomField.build(custom_field) }
+    @custom_fields = custom_fields.map { |custom_field| Moneybird::Resource::CustomField.build(custom_field) }
   end
 end

--- a/lib/moneybird/resource/recurring_sales_invoice.rb
+++ b/lib/moneybird/resource/recurring_sales_invoice.rb
@@ -40,7 +40,7 @@ module Moneybird::Resource
     )
 
     def notes=(notes)
-      @notes ||= notes.map{ |note| Moneybird::Resource::Generic::Note.build(note) }
+      @notes = notes.map{ |note| Moneybird::Resource::Generic::Note.build(note) }
     end
 
     def contact=(attributes)
@@ -52,7 +52,7 @@ module Moneybird::Resource
     end
 
     def events=(events)
-      @events ||= events.map{ |event| Moneybird::Resource::Generic::Event.build(event) }
+      @events = events.map{ |event| Moneybird::Resource::Generic::Event.build(event) }
     end
   end
 end

--- a/lib/moneybird/resource/sales_invoice.rb
+++ b/lib/moneybird/resource/sales_invoice.rb
@@ -55,7 +55,7 @@ module Moneybird::Resource
     )
 
     def notes=(notes)
-      @notes ||= notes.map{ |note| Moneybird::Resource::Generic::Note.build(note) }
+      @notes = notes.map{ |note| Moneybird::Resource::Generic::Note.build(note) }
     end
 
     def contact=(attributes)
@@ -82,11 +82,11 @@ module Moneybird::Resource
     end
 
     def events=(events)
-      @events ||= events.map{ |event| Moneybird::Resource::Generic::Event.build(event) }
+      @events = events.map{ |event| Moneybird::Resource::Generic::Event.build(event) }
     end
 
     def custom_fields=(custom_fields)
-      @custom_fields ||= custom_fields.map { |custom_field| Moneybird::Resource::CustomField.build(custom_field) }
+      @custom_fields = custom_fields.map { |custom_field| Moneybird::Resource::CustomField.build(custom_field) }
     end
   end
 end


### PR DESCRIPTION
This fixes an issue where updates to some attributes resulting from an API call would not appear on the object passed to that API call. It also makes the setters have a more regular behavior.
