### PR TITLE
[WIP] Only process json when it's json

### DIFF
--- a/lib/moneybird/client.rb
+++ b/lib/moneybird/client.rb
@@ -36,12 +36,12 @@ module Moneybird
 
     %i[get patch post delete].each do |call|
       define_method call do |path, options = {}|
-        http.public_send(call, "/api/#{version}/#{path}", options).body
-
-      rescue Faraday::ParsingError => e
-        return e.response['Location'] if e.response.status == 302
-
-        raise e
+        response = http.public_send(call, "/api/#{version}/#{path}", options)
+        if response.status == 302
+          response['Location']
+        else
+          response.body
+        end
       end
     end
 

--- a/lib/moneybird/client.rb
+++ b/lib/moneybird/client.rb
@@ -26,7 +26,7 @@ module Moneybird
       @http ||= Faraday.new(url: base_url) do |faraday|
         faraday.headers = faraday_headers
         faraday.request :url_encoded
-        faraday.response :json
+        faraday.response :json, content_type: /\bjson$/
         faraday.use Moneybird::Middleware::ErrorHandling
         faraday.use Moneybird::Middleware::Pagination
 

--- a/spec/lib/moneybird/service/sales_invoice_spec.rb
+++ b/spec/lib/moneybird/service/sales_invoice_spec.rb
@@ -43,7 +43,7 @@ describe Moneybird::Service::SalesInvoice do
   describe "#send_invoice" do
     before do
       stub_request(:patch, 'https://moneybird.com/api/v2/123/sales_invoices/456/send_invoice')
-        .to_return(status: 200, body: fixture_response(:sales_invoice))
+        .to_return(status: 200, headers: { content_type: "application/json" }, body: fixture_response(:sales_invoice))
     end
     let(:sales_invoice) { Moneybird::Resource::SalesInvoice.new(client: client, id: '456') }
     it "will send the invoice" do


### PR DESCRIPTION
In Faraday 2, the Json middleware will only process a response body as json if the content type is actually json. This pull request prepares for this.

Still to do:

- [ ] Stub all test requests to return json content type (ugh!)
- [x] Adjust the redirect handler that currently relies on a json parsing exception to detect potential redirects