### PR TITLE
Update codeclimate configuration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,4 +23,3 @@ ratings:
   - "**.rb"
 exclude_paths:
 - spec/
-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   DisabledByDefault: true
+  TargetRubyVersion: 2.5
 
 #################### Lint ################################
 

--- a/moneybird.gemspec
+++ b/moneybird.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "simplecov", "= 0.21.2"
   spec.add_development_dependency "minitest"
+  spec.add_development_dependency "rubocop", "~> 0.52.1"
   spec.add_development_dependency "webmock", "~> 3.1"
 end


### PR DESCRIPTION
I would like to achieve the following:

1. be able to run rubocop locally, preferally with the same version that codeclimate uses
2. update rubocop configuration so it won't try and fail to parse using Ruby 2.1 syntax in codeclimate

Codeclimate claims it uses rubocop 0.52.1 (https://docs.codeclimate.com/docs/rubocop), but that version gives errors with the current `.rubocop.yml`.