### PR TITLE
Update test fixtures with missing resource attributes

### DIFF
--- a/spec/fixtures/responses/contact.json
+++ b/spec/fixtures/responses/contact.json
@@ -36,6 +36,7 @@
   "tax_number_valid": null,
   "invoice_workflow_id": null,
   "estimate_workflow_id": null,
+  "moneybird_payments_mandate": false,
   "created_at": "2017-07-13T07:52:16.322Z",
   "updated_at": "2017-07-13T07:52:16.322Z",
   "sales_invoices_url": "http://moneybird.dev/123/sales_invoices/e0dc4f48ad7bd8f3746d55e97b09482e027029b6cf5bf1f84475fec7d2a57301/all",
@@ -50,6 +51,22 @@
       "value": "Value"
     }
   ],
+  "contact_people": [
+    {
+      "id": "416087480780981378",
+      "contact_id": "416087480773641344",
+      "administration_id": 123,
+      "firstname": "John",
+      "lastname": "Doe",
+      "phone": null,
+      "email": null,
+      "department": null,
+      "created_at": "2024-03-21T14:39:25.518Z",
+      "updated_at": "2024-03-21T14:39:25.518Z",
+      "version": 1711031965
+    }
+  ],
+  "archived": false,
   "events": [
     {
       "administration_id": 123,

--- a/spec/fixtures/responses/contacts.json
+++ b/spec/fixtures/responses/contacts.json
@@ -37,6 +37,7 @@
     "tax_number_valid": null,
     "invoice_workflow_id": null,
     "estimate_workflow_id": null,
+    "moneybird_payments_mandate": false,
     "created_at": "2017-07-13T07:52:14.634Z",
     "updated_at": "2017-07-13T07:52:14.634Z",
     "sales_invoices_url": "http://moneybird.dev/123/sales_invoices/59481dc990fb2c7444c404cb15f06697dc41e56fe151df0fbf29e209ef7be486/all",
@@ -46,6 +47,10 @@
     "custom_fields": [
 
     ],
+    "contact_people": [
+
+    ],
+    "archived": false,
     "events": [
       {
         "administration_id": 123,
@@ -97,6 +102,7 @@
     "tax_number_valid": null,
     "invoice_workflow_id": null,
     "estimate_workflow_id": null,
+    "moneybird_payments_mandate": false,
     "created_at": "2017-07-13T07:52:14.572Z",
     "updated_at": "2017-07-13T07:52:14.572Z",
     "sales_invoices_url": "http://moneybird.dev/123/sales_invoices/e59a49d5fbbc3abff472848935402c99b6b2835f26ec525056f5786a41dc3f29/all",
@@ -111,6 +117,10 @@
         "value": "Value"
       }
     ],
+    "contact_people": [
+
+    ],
+    "archived": false,
     "events": [
       {
         "administration_id": 123,
@@ -162,6 +172,7 @@
     "tax_number_valid": null,
     "invoice_workflow_id": null,
     "estimate_workflow_id": null,
+    "moneybird_payments_mandate": false,
     "created_at": "2017-07-13T07:52:14.608Z",
     "updated_at": "2017-07-13T07:52:14.608Z",
     "sales_invoices_url": "http://moneybird.dev/123/sales_invoices/4761794890a379797fcc02e77a8f21ab1eb621f2aa879766568afb6a24582d3b/all",
@@ -176,6 +187,10 @@
         "value": "Value"
       }
     ],
+    "contact_people": [
+
+    ],
+    "archived": false,
     "events": [
       {
         "administration_id": 123,

--- a/spec/fixtures/responses/sales_invoice.json
+++ b/spec/fixtures/responses/sales_invoice.json
@@ -47,6 +47,8 @@
 
     ]
   },
+  "contact_person_id": null,
+  "contact_person": null,
   "invoice_id": "2017-0001",
   "recurring_sales_invoice_id": null,
   "workflow_id": "181903403083892150",
@@ -57,6 +59,7 @@
   "invoice_date": "2017-02-21",
   "due_date": "2017-03-07",
   "payment_conditions": "We verzoeken u vriendelijk het bovenstaande bedrag van {document.total_price} voor {document.due_date} te voldoen op onze bankrekening onder vermelding van het factuurnummer {document.invoice_id}. Voor vragen kunt u contact opnemen per e-mail.",
+  "short_payment_reference": "RF07C99N9AAZ",
   "reference": "Project X",
   "language": "nl",
   "currency": "EUR",
@@ -66,6 +69,7 @@
   "sent_at": "2017-02-21",
   "created_at": "2017-02-21T17:06:07.811Z",
   "updated_at": "2017-02-21T17:06:08.005Z",
+  "public_view_code_expires_at": "2024-06-21T14:42:09.689Z",
   "details": [
     {
       "id": "181903552513311776",
@@ -82,6 +86,7 @@
       "tax_report_reference": [
         "NL/1a"
       ],
+      "mandatory_tax_text": null,
       "created_at": "2017-02-21T17:06:07.815Z",
       "updated_at": "2017-02-21T17:06:08.002Z"
     }
@@ -97,6 +102,9 @@
   "total_price_excl_tax_base": "300.0",
   "total_price_incl_tax": "363.0",
   "total_price_incl_tax_base": "363.0",
+  "reminder_count": 0,
+  "next_reminder": "2024-04-04",
+  "original_estimate_id": null,
   "url": "http://moneybird.dev/123/sales_invoices/7090c100b6c2c3a3f0dfb7c5f21431c5fa5b40817c091e4b1941234cc209d8ea/e807722dc8338cfa5b7ca895a78bd49868385b145730027758013f7a780a7890",
   "custom_fields": [
     {

--- a/spec/fixtures/responses/sales_invoices.json
+++ b/spec/fixtures/responses/sales_invoices.json
@@ -51,6 +51,8 @@
 
       ]
     },
+    "contact_person_id": null,
+    "contact_person": null,
     "invoice_id": "2017-0003",
     "recurring_sales_invoice_id": null,
     "workflow_id": "194733447301826126",
@@ -61,6 +63,7 @@
     "invoice_date": "2017-07-13",
     "due_date": "2017-07-27",
     "payment_conditions": "We verzoeken u vriendelijk het bovenstaande bedrag van {document.total_price} voor {document.due_date} te voldoen op onze bankrekening onder vermelding van het factuurnummer {document.invoice_id}. Voor vragen kunt u contact opnemen per e-mail.",
+    "short_payment_reference": "RF07C99N9AAZ",
     "reference": "Project X",
     "language": "nl",
     "currency": "EUR",
@@ -70,6 +73,7 @@
     "sent_at": "2017-07-13",
     "created_at": "2017-07-13T07:53:43.577Z",
     "updated_at": "2017-07-13T07:53:43.876Z",
+    "public_view_code_expires_at": "2024-06-21T14:42:09.689Z",
     "details": [
       {
         "id": "194733567499044116",
@@ -88,6 +92,7 @@
         "tax_report_reference": [
           "NL/1a"
         ],
+        "mandatory_tax_text": null,
         "created_at": "2017-07-13T07:53:43.584Z",
         "updated_at": "2017-07-13T07:53:43.874Z"
       }
@@ -104,6 +109,9 @@
     "total_price_incl_tax": "363.0",
     "total_price_incl_tax_base": "363.0",
     "total_discount": "0.0",
+    "reminder_count": 0,
+    "next_reminder": "2024-04-04",
+    "original_estimate_id": null,
     "url": "http://moneybird.dev/123/sales_invoices/19625755314e0e441429848b52afb0edb2138e51da11fa6bcc8aee69fe7c1a0f/7ab9c063c7d9bde8103aa292f209607fd2f44b637d878b6389ef180822446132",
     "custom_fields": [
       {
@@ -206,6 +214,8 @@
 
       ]
     },
+    "contact_person_id": null,
+    "contact_person": null,
     "invoice_id": "2017-0002",
     "recurring_sales_invoice_id": null,
     "workflow_id": "194733447301826126",
@@ -216,6 +226,7 @@
     "invoice_date": "2017-07-13",
     "due_date": "2017-07-27",
     "payment_conditions": "We verzoeken u vriendelijk het bovenstaande bedrag van {document.total_price} voor {document.due_date} te voldoen op onze bankrekening onder vermelding van het factuurnummer {document.invoice_id}. Voor vragen kunt u contact opnemen per e-mail.",
+    "short_payment_reference": "RF07C99N9AAZ",
     "reference": "Project X",
     "language": "nl",
     "currency": "EUR",
@@ -225,6 +236,7 @@
     "sent_at": "2017-07-13",
     "created_at": "2017-07-13T07:53:43.091Z",
     "updated_at": "2017-07-13T07:53:43.362Z",
+    "public_view_code_expires_at": "2024-06-21T14:42:09.689Z",
     "details": [
       {
         "id": "194733566987339024",
@@ -243,6 +255,7 @@
         "tax_report_reference": [
           "NL/1a"
         ],
+        "mandatory_tax_text": null,
         "created_at": "2017-07-13T07:53:43.096Z",
         "updated_at": "2017-07-13T07:53:43.358Z"
       }
@@ -259,6 +272,9 @@
     "total_price_incl_tax": "363.0",
     "total_price_incl_tax_base": "363.0",
     "total_discount": "0.0",
+    "reminder_count": 0,
+    "next_reminder": "2024-04-04",
+    "original_estimate_id": null,
     "url": "http://moneybird.dev/123/sales_invoices/ee32883b444f2e1b4cca79df9d17e22ae8dd7dd114ffa92bf39330f09f3eef8d/7ab9c063c7d9bde8103aa292f209607fd2f44b637d878b6389ef180822446132",
     "custom_fields": [
       {
@@ -361,6 +377,8 @@
 
       ]
     },
+    "contact_person_id": null,
+    "contact_person": null,
     "invoice_id": "2017-0001",
     "recurring_sales_invoice_id": null,
     "workflow_id": "194733447301826126",
@@ -371,6 +389,7 @@
     "invoice_date": "2017-07-13",
     "due_date": "2017-07-27",
     "payment_conditions": "We verzoeken u vriendelijk het bovenstaande bedrag van {document.total_price} voor {document.due_date} te voldoen op onze bankrekening onder vermelding van het factuurnummer {document.invoice_id}. Voor vragen kunt u contact opnemen per e-mail.",
+    "short_payment_reference": "RF07C99N9AAZ",
     "reference": "Project X",
     "language": "nl",
     "currency": "EUR",
@@ -380,6 +399,7 @@
     "sent_at": "2017-07-13",
     "created_at": "2017-07-13T07:53:42.711Z",
     "updated_at": "2017-07-13T07:53:42.919Z",
+    "public_view_code_expires_at": "2024-06-21T14:42:09.689Z",
     "details": [
       {
         "id": "194733566588880139",
@@ -398,6 +418,7 @@
         "tax_report_reference": [
           "NL/1a"
         ],
+        "mandatory_tax_text": null,
         "created_at": "2017-07-13T07:53:42.717Z",
         "updated_at": "2017-07-13T07:53:42.916Z"
       }
@@ -414,6 +435,9 @@
     "total_price_incl_tax": "363.0",
     "total_price_incl_tax_base": "363.0",
     "total_discount": "0.0",
+    "reminder_count": 0,
+    "next_reminder": "2024-04-04",
+    "original_estimate_id": null,
     "url": "http://moneybird.dev/123/sales_invoices/74a2cb84987e0a48aceddd29d582962ca832cb088c729f5c70386ee18a6b31f5/7ab9c063c7d9bde8103aa292f209607fd2f44b637d878b6389ef180822446132",
     "custom_fields": [
       {

--- a/spec/fixtures/responses/tax_rates.json
+++ b/spec/fixtures/responses/tax_rates.json
@@ -7,6 +7,7 @@
     "tax_rate_type": "sales_invoice",
     "show_tax": true,
     "active": true,
+    "country": null,
     "created_at": "2015-12-23T07:43:17.881Z",
     "updated_at": "2015-12-23T07:43:17.881Z"
   },
@@ -18,6 +19,7 @@
     "tax_rate_type": "sales_invoice",
     "show_tax": true,
     "active": true,
+    "country": null,
     "created_at": "2015-12-23T07:43:17.890Z",
     "updated_at": "2015-12-23T07:43:17.890Z"
   },
@@ -29,6 +31,7 @@
     "tax_rate_type": "sales_invoice",
     "show_tax": true,
     "active": true,
+    "country": null,
     "created_at": "2015-12-23T07:43:17.897Z",
     "updated_at": "2015-12-23T07:43:17.897Z"
   }

--- a/spec/fixtures/webhooks/sales_invoice.json
+++ b/spec/fixtures/webhooks/sales_invoice.json
@@ -43,12 +43,15 @@
 
       ]
     },
+    "contact_person_id": null,
+    "contact_person": null,
     "invoice_id": null,
     "workflow_id": 116015053116802148,
     "document_style_id": 116015053175522406,
     "state": "late",
     "invoice_date": null,
     "payment_conditions": "We verzoeken u vriendelijk het bovenstaande bedrag van {document.total_price} voor {document.due_date} te voldoen op onze bankrekening onder vermelding van het factuurnummer {document.invoice_id}. Voor vragen kunt u contact opnemen per e-mail.",
+    "short_payment_reference": "RF07C99N9AAZ",
     "reference": "Project X",
     "language": "nl",
     "currency": "EUR",
@@ -57,6 +60,7 @@
     "sent_at": null,
     "created_at": "2015-02-25T10:39:41.685Z",
     "updated_at": "2015-02-25T10:39:41.685Z",
+    "public_view_code_expires_at": "2024-06-21T14:42:09.689Z",
     "details": [
       {
         "id": 116015245648987144,
@@ -71,6 +75,7 @@
         "tax_report_reference": [
           "NL/1a"
         ],
+        "public_view_code_expires_at": "2024-06-21T14:42:09.689Z",
         "created_at": "2015-02-25T10:39:41.693Z",
         "updated_at": "2015-02-25T10:39:41.693Z"
       }
@@ -78,6 +83,9 @@
     "payments": [
 
     ],
+    "reminder_count": 0,
+    "next_reminder": "2024-04-04",
+    "original_estimate_id": null,
     "custom_fields": [
 
     ],


### PR DESCRIPTION
This pull request updates test fixtures with missing attributes from `TaxRate`, `Contact`, `SalesInvoice`, and `Invoice::Details` resources, added on previous PR https://github.com/maartenvanvliet/moneybird/pull/85

Below are the attributes added:

- **TaxRate**: country
- **Contact**: archived, contact_people, moneybird_payments_mandate
- **SalesInvoice**: contact_person, contact_person_id, next_reminder, original_estimate_id, public_view_code_expires_at, reminder_count, short_payment_reference
- **Invoice::Details**: mandatory_tax_text