### PR TITLE
feat: Rename events to enabled_events

### DIFF
--- a/lib/moneybird/resource/webhook.rb
+++ b/lib/moneybird/resource/webhook.rb
@@ -9,7 +9,7 @@ module Moneybird::Resource
       url
       last_http_status
       last_http_body
-      events
+      enabled_events
       token
     )
 

--- a/spec/fixtures/responses/webhook.json
+++ b/spec/fixtures/responses/webhook.json
@@ -2,7 +2,7 @@
   "id": "194733605680842680",
   "administration_id": 123,
   "url": "http://example.com/webhook",
-  "events": [
+  "enabled_events": [
 
   ],
   "last_http_status": null,

--- a/spec/fixtures/responses/webhooks.json
+++ b/spec/fixtures/responses/webhooks.json
@@ -3,7 +3,7 @@
     "id": "194733605680842680",
     "administration_id": 123,
     "url": "http://www.mocky.io/v2/5185415ba171ea3a00704eed",
-    "events": [
+    "enabled_events": [
 
     ],
     "last_http_status": null,

--- a/spec/lib/moneybird/resources/webhook_spec.rb
+++ b/spec/lib/moneybird/resources/webhook_spec.rb
@@ -10,7 +10,7 @@ describe Moneybird::Resource::Webhook do
         "id" => "194733605680842680",
         "administration_id" => 123,
         "url" => "http://example.com/webhook",
-        "events" => []
+        "enabled_events" => []
       }
     )
   end


### PR DESCRIPTION
According to https://developer.moneybird.com/api/webhooks the events properties was replaced by the enabled_events property.